### PR TITLE
Improve PAM onboarding script and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.log
+pam_*_commands.txt
+pam_records_import.json
+*.csv

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## TL;DR
 
 ```bash
-python3 create_pam_script_improved_fixed.py \
+python3 create_pam_script_improved.py \
   --gateway-uid <GW_UID> \
   --csv servers_to_import.csv \
   --user-folder PAM_Users \
@@ -38,6 +38,29 @@ bash pam_rotation_commands.txt
 ```
 
 *Everything* will be wired, enabled and scheduled – zero manual edits.
+
+### Using the custom Commander fork
+
+This project relies on the [pam-import-add-directory-admin-for-local-machines](https://github.com/Keeper-Security/Commander/tree/pam-import-add-directory-admin-for-local-machines) branch of **Keeper Commander**.
+Clone the repository and install it with `pip install -e .` before running the
+commands below.
+
+### Converting CSV to JSON
+
+Give the script a simple CSV with `hostname,initial_admin_user,initial_admin_password` and it will produce `pam_records_import.json` along with the helper command files.
+For example the CSV
+
+```csv
+server1,admin,1234
+server2,admin,1234
+server3,admin,1234
+```
+
+becomes a JSON wrapper ready for `keeper import` once you run:
+
+```bash
+python3 create_pam_script_improved.py --gateway-uid <GW_UID> --csv servers.csv
+```
 
 ---
 
@@ -84,13 +107,13 @@ Run `--help` for the full list.
 
 ## Generated artefacts
 
-| File    | What it contains                                                       |
-| ------- | ---------------------------------------------------------------------- |
-| \`\`    | Ready‑to‑import records (wrapper + blank `$pamSettings`)               |
-| \`\`    | `keeper import` + `pam config new` + optional `folder move`            |
-| \`\`    | One `pam connection edit` per machine (includes `--config`)            |
-| \`\`    | One `pam rotation set` per credential (includes `--config` & schedule) |
-| **Log** | `bulk_onboard_YYYYMMDDThhmmssZ.log` – INFO/WARN/ERROR lines            |
+| File | What it contains |
+| ------- | ---------------- |
+| `pam_records_import.json` | Ready-to-import records (wrapper + blank `$pamSettings`) |
+| `pam_setup_commands.txt` | `keeper import` + `pam config new` + optional `folder move` |
+| `pam_connection_commands.txt` | One `pam connection edit` per machine (includes `--config`) |
+| `pam_rotation_commands.txt` | One `pam rotation set` per credential (includes `--config` & schedule) |
+| **Log** | `bulk_onboard_YYYYMMDDThhmmssZ.log` – INFO/WARN/ERROR lines |
 
 ---
 
@@ -107,11 +130,21 @@ Run `--help` for the full list.
    pam connection list --folder "/PAM_Resources"
    pam rotation  list --folder "/PAM_Users"
    ```
+7. **Run tests** – `pytest`.
 
 ---
 
 ## FAQ
 
 ---
+
+**Q: Can I run the script multiple times?**
+
+Yes. Duplicate hostnames in the CSV are ignored with a warning in the log.
+
+**Q: What happens if a server is unreachable?**
+
+Use `--connectivity-check` to probe TCP 5986. Hosts that fail the check are
+skipped so the generated files contain only reachable machines.
 
 

--- a/create_pam_script_improved.py
+++ b/create_pam_script_improved.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-create_pam_script_improved_fixed.py -- Bulk‑onboard Windows servers into Keeper PAM
+create_pam_script_improved.py -- Bulk‑onboard Windows servers into Keeper PAM
 
 Changelog vs original GitHub version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -12,7 +12,8 @@ Changelog vs original GitHub version
   attached in one shot.
 * Rotation commands include **--config** and use the **--admin-user** UID you
   supply – no more fallback to the rotated credential.
-* Schedule string is emitted as valid JSON: `{"type":"DAILY","time":"02:00","tz":"UTC"}`.
+* Schedule string is emitted as valid JSON:
+ `{"type":"DAILY","time":"02:00","tz":"UTC"}`.
 * Added doc‑level constants for default ports per protocol.
 * Misc: PEP‑8 pass, clearer logging, `--dry-run` honours new files.
 
@@ -45,7 +46,8 @@ logger.addHandler(console)
 
 # file log
 file_handler = logging.FileHandler(
-    Path(f"bulk_onboard_{datetime.utcnow():%Y%m%dT%H%M%SZ}.log"))
+    Path(f"bulk_onboard_{datetime.utcnow():%Y%m%dT%H%M%SZ}.log")
+)
 file_handler.setFormatter(logging.Formatter(LOG_FMT))
 logger.addHandler(file_handler)
 
@@ -60,62 +62,104 @@ _DEFAULT_PORTS = {
     "postgresql": 5432,
 }
 
+
 def _probe(host: str, port: int = 5986, timeout: float = 3.0) -> bool:
+    """Return True if ``host:port`` accepts a TCP connection."""
+
     try:
         with socket.create_connection((host, port), timeout):
             return True
     except OSError:
         return False
 
+
 # ──────────────────────────────────────────────────────────────────────────────
 # CLI
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 def _build_cli() -> argparse.ArgumentParser:
+    """Return the argument parser for the script."""
+
     p = argparse.ArgumentParser(
         description="Generate Keeper PAM import JSON & CLI commands",
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
     # core
-    p.add_argument("--gateway-uid", required=True, help="UID of Keeper Gateway")
-    p.add_argument("--csv", default="servers_to_import.csv",
-                   help="CSV with hostname,user,password (default: %(default)s)")
+    p.add_argument(
+        "--gateway-uid", required=True, help="UID of Keeper Gateway"
+    )
+    p.add_argument(
+        "--csv",
+        default="servers_to_import.csv",
+        help="CSV with hostname,user,password (default: %(default)s)",
+    )
 
-    p.add_argument("--user-folder", default="PAM_Users",
-                   help="SF name for pamUser records (default: %(default)s)")
-    p.add_argument("--resource-folder", default="PAM_Resources",
-                   help="SF name for pamMachine records (default: %(default)s)")
-    p.add_argument("--parent-folder", default=None,
-                   help="Existing parent SF path to nest user/resource folders")
+    p.add_argument(
+        "--user-folder",
+        default="PAM_Users",
+        help="SF name for pamUser records (default: %(default)s)",
+    )
+    p.add_argument(
+        "--resource-folder",
+        default="PAM_Resources",
+        help="SF name for pamMachine records (default: %(default)s)",
+    )
+    p.add_argument(
+        "--parent-folder",
+        default=None,
+        help="Existing parent SF path to nest user/resource folders",
+    )
 
     # rotation / schedule
-    p.add_argument("--rotation-admin-uid", required=False,
-                   help="UID of pamUser used to perform resets")
-    p.add_argument("--schedulejson",
-                   default='{"type":"DAILY","time":"02:00","tz":"UTC"}',
-                   help="JSON schedule. MUST be valid JSON (default: %(default)s)")
+    p.add_argument(
+        "--rotation-admin-uid",
+        required=False,
+        help="UID of pamUser used to perform resets",
+    )
+    p.add_argument(
+        "--schedulejson",
+        default='{"type":"DAILY","time":"02:00","tz":"UTC"}',
+        help="JSON schedule. MUST be valid JSON (default: %(default)s)",
+    )
 
     # connection / machine specifics
-    p.add_argument("--protocol", default="rdp", choices=list(_DEFAULT_PORTS),
-                   help="Protocol for connections (default: %(default)s)")
-    p.add_argument("--os", default="Windows",
-                   help="Operating system string (default: %(default)s)")
-    p.add_argument("--enable-ssl-verification", action="store_true",
-                   help="Enable SSL verification flag on machines")
+    p.add_argument(
+        "--protocol",
+        default="rdp",
+        choices=list(_DEFAULT_PORTS),
+        help="Protocol for connections (default: %(default)s)",
+    )
+    p.add_argument(
+        "--os",
+        default="Windows",
+        help="Operating system string (default: %(default)s)",
+    )
+    p.add_argument(
+        "--enable-ssl-verification",
+        action="store_true",
+        help="Enable SSL verification flag on machines",
+    )
 
     # feature flags
     p.add_argument("--dry-run", action="store_true")
     p.add_argument("--connectivity-check", action="store_true")
-    p.add_argument("--threads", type=int, default=min(32, (os.cpu_count() or 1) * 5))
+    p.add_argument(
+        "--threads", type=int, default=min(32, (os.cpu_count() or 1) * 5)
+    )
 
     return p
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Read CSV
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 def _read_csv(path: Path) -> List[Dict[str, str]]:
+    """Return a list of host dictionaries loaded from ``path``."""
+
     if not path.exists():
         logger.error("CSV file not found: %s", path)
         sys.exit(1)
@@ -123,20 +167,28 @@ def _read_csv(path: Path) -> List[Dict[str, str]]:
     with path.open(encoding="utf-8") as fp:
         reader = csv.DictReader(fp)
         for line_no, row in enumerate(reader, 1):
-            h, u, p = (row.get("hostname", "").strip(),
-                        row.get("initial_admin_user", "").strip(),
-                        row.get("initial_admin_password", "").strip())
+            h, u, p = (
+                row.get("hostname", "").strip(),
+                row.get("initial_admin_user", "").strip(),
+                row.get("initial_admin_password", "").strip(),
+            )
             if not all((h, u, p)):
                 logger.warning("Row %d incomplete – skipped", line_no)
                 continue
             out.append({"hostname": h, "user": u, "password": p})
     return out
 
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Record generation
 # ──────────────────────────────────────────────────────────────────────────────
 
-def _gen_records(rows: List[Dict[str, str]], args: argparse.Namespace) -> List[Dict]:
+
+def _gen_records(
+    rows: List[Dict[str, str]], args: argparse.Namespace
+) -> List[Dict]:
+    """Return Keeper record dictionaries for ``rows``."""
+
     recs: List[Dict] = []
     seen: set[str] = set()
     port = str(_DEFAULT_PORTS[args.protocol])
@@ -149,45 +201,56 @@ def _gen_records(rows: List[Dict[str, str]], args: argparse.Namespace) -> List[D
         tmp_uid = uuid.uuid4().hex
 
         # pamUser
-        recs.append({
-            "$type": "pamUser",
-            "uid": tmp_uid,
-            "title": f"{host} Local Admin",
-            "login": row["user"],
-            "password": row["password"],
-            "folders": [{
-                "shared_folder": args.user_folder,
-                "can_edit": True,
-                "can_share": True,
-            }],
-        })
+        recs.append(
+            {
+                "$type": "pamUser",
+                "uid": tmp_uid,
+                "title": f"{host} Local Admin",
+                "login": row["user"],
+                "password": row["password"],
+                "folders": [
+                    {
+                        "shared_folder": args.user_folder,
+                        "can_edit": True,
+                        "can_share": True,
+                    }
+                ],
+            }
+        )
 
         # pamMachine
-        recs.append({
-            "$type": "pamMachine",
-            "title": host,
-            "login": "stub",
-            "password": "stub",
-            "folders": [{
-                "shared_folder": args.resource_folder,
-                "can_edit": True,
-                "can_share": True,
-            }],
-            "custom_fields": {
-                "$pamSettings": {"connection": {}, "portForward": {}},
-                "$pamHostname": {"hostName": host, "port": port},
-                "$checkbox:sslVerification": args.enable_ssl_verification,
-                "operatingSystem": args.os,
-            },
-            "links": [tmp_uid],
-        })
+        recs.append(
+            {
+                "$type": "pamMachine",
+                "title": host,
+                "login": "stub",
+                "password": "stub",
+                "folders": [
+                    {
+                        "shared_folder": args.resource_folder,
+                        "can_edit": True,
+                        "can_share": True,
+                    }
+                ],
+                "custom_fields": {
+                    "$pamSettings": {"connection": {}, "portForward": {}},
+                    "$pamHostname": {"hostName": host, "port": port},
+                    "$checkbox:sslVerification": args.enable_ssl_verification,
+                    "operatingSystem": args.os,
+                },
+                "links": [tmp_uid],
+            }
+        )
     return recs
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Command writers
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 def _write(fpath: Path, content: str, dry: bool):
+    """Write ``content`` to ``fpath`` unless ``dry`` is True."""
     if dry:
         logger.info("[DRY‑RUN] Would write %s", fpath)
         return
@@ -197,34 +260,53 @@ def _write(fpath: Path, content: str, dry: bool):
 
 
 def _cmdfile_header(title: str) -> str:
-    return f"# ==== {title} generated {datetime.utcnow():%Y-%m-%dT%H:%MZ} ===\n\n"
+    """Return a common header line for command files."""
+
+    return (
+        f"# ==== {title} generated {datetime.utcnow():%Y-%m-%dT%H:%MZ} ===\n\n"
+    )
 
 
 def write_import_json(records: List[Dict], args: argparse.Namespace):
+    """Write ``records`` to ``pam_records_import.json``."""
+
     wrapper = json.dumps({"shared_folders": [], "records": records}, indent=2)
     _write(Path("pam_records_import.json"), wrapper, args.dry_run)
 
 
 def write_setup_commands(args: argparse.Namespace):
-    lines = [_cmdfile_header("SETUP"),
-             "keeper import pam_records_import.json --format json\n"]
+    """Create setup commands for configs and optional folder moves."""
+    lines = [
+        _cmdfile_header("SETUP"),
+        "keeper import pam_records_import.json --format json\n",
+    ]
 
     # One config per resource folder
     cfg_title = f"Config for {args.resource_folder}"
     cfg_cmd = (
         f'keeper pam config new --environment local --title "{cfg_title}" '
         f'--shared-folder "{args.resource_folder}" -g {args.gateway_uid} '
-        f'--connections=on --rotation=on')
+        f"--connections=on --rotation=on"
+    )
     lines.append(cfg_cmd + "\n")
 
     # optional folder moves
     if args.parent_folder:
         for sf in (args.user_folder, args.resource_folder):
-            lines.append(f'keeper folder move "/{sf}" "/{args.parent_folder}/{sf}"')
-    _write(Path("pam_setup_commands.txt"), "\n".join(lines), args.dry_run)
+            lines.append(
+                f'keeper folder move "/{sf}" "/{args.parent_folder}/{sf}"'
+            )
+    _write(
+        Path("pam_setup_commands.txt"),
+        "\n".join(lines) + "\n",
+        args.dry_run,
+    )
 
 
-def write_connection_commands(rows: List[Dict[str, str]], args: argparse.Namespace):
+def write_connection_commands(
+    rows: List[Dict[str, str]], args: argparse.Namespace
+):
+    """Write pam connection commands to a file."""
     cfg_path = f'"/{args.resource_folder}"'
     lines = [_cmdfile_header("CONNECTIONS")]
     for row in rows:
@@ -233,36 +315,61 @@ def write_connection_commands(rows: List[Dict[str, str]], args: argparse.Namespa
         user = f'"/{args.user_folder}/{host} Local Admin"'
         port = _DEFAULT_PORTS[args.protocol]
         lines.append(
-            "keeper pam connection edit {m} --config {c} --admin-user {u} "
-            "--protocol {p} --connections on --connections-override-port {port}".format(
-                m=machine, c=cfg_path, u=user, p=args.protocol, port=port))
-    _write(Path("pam_connection_commands.txt"), "\n".join(lines), args.dry_run)
+            (
+                f"keeper pam connection edit {machine} --config {cfg_path} "
+                f"--admin-user {user} --protocol {args.protocol} "
+                f"--connections on --connections-override-port {port}"
+            )
+        )
+    _write(
+        Path("pam_connection_commands.txt"),
+        "\n".join(lines) + "\n",
+        args.dry_run,
+    )
 
 
-def write_rotation_commands(rows: List[Dict[str, str]], args: argparse.Namespace):
+def write_rotation_commands(
+    rows: List[Dict[str, str]], args: argparse.Namespace
+):
+    """Write pam rotation commands to ``pam_rotation_commands.txt``."""
     cfg_path = f'"/{args.resource_folder}"'
-    sched = args.schedulejson.replace("'", "\"")  # ensure double‑quoted JSON
+    sched = args.schedulejson.replace("'", '"')  # ensure double‑quoted JSON
     lines = [_cmdfile_header("ROTATION")]
-    adm_flag = f'--admin-user {args.rotation_admin_uid}' if args.rotation_admin_uid else ''
+    adm_flag = (
+        f" --admin-user {args.rotation_admin_uid}"
+        if args.rotation_admin_uid
+        else ""
+    )
     for row in rows:
         host = row["hostname"]
         user = f'"/{args.user_folder}/{host} Local Admin"'
         machine = f'"/{args.resource_folder}/{host}"'
         lines.append(
-            "keeper pam rotation set --record {u} --resource {m} --config {c} "
-            "--enable {adm} -sj '{sj}'".format(
-                u=user, m=machine, c=cfg_path, adm=adm_flag, sj=sched))
-    _write(Path("pam_rotation_commands.txt"), "\n".join(lines), args.dry_run)
+            (
+                "keeper pam rotation set --record {u} --resource {m} "
+                "--config {c} --enable{adm} -sj '{sj}'"
+            ).format(u=user, m=machine, c=cfg_path, adm=adm_flag, sj=sched)
+        )
+    _write(
+        Path("pam_rotation_commands.txt"),
+        "\n".join(lines) + "\n",
+        args.dry_run,
+    )
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Main
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 def main():
+    """Entry point for CLI execution."""
     args = _build_cli().parse_args()
     rows = _read_csv(Path(args.csv))
     if args.connectivity_check:
-        logger.info("Running best‑effort TCP 5986 probe on %d hosts", len(rows))
+        logger.info(
+            "Running best‑effort TCP 5986 probe on %d hosts", len(rows)
+        )
         ok: List[Dict] = []
         with ThreadPoolExecutor(max_workers=args.threads) as ex:
             fut = {ex.submit(_probe, r["hostname"]): r for r in rows}
@@ -279,6 +386,7 @@ def main():
     write_setup_commands(args)
     write_connection_commands(rows, args)
     write_rotation_commands(rows, args)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import json  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+import create_pam_script_improved as script  # noqa: E402
+
+
+def test_write_import_json(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_write(path, content, dry):
+        captured["path"] = Path(path)
+        captured["content"] = content
+        captured["dry"] = dry
+
+    monkeypatch.setattr(script, "_write", fake_write)
+    records = [{"uid": "1"}]
+    args = SimpleNamespace(dry_run=False)
+    script.write_import_json(records, args)
+    data = json.loads(captured["content"])
+    assert data["records"] == records
+    assert captured["path"].name == "pam_records_import.json"
+
+
+def test_rotation_command_format(monkeypatch):
+    captured = {}
+
+    def fake_write(path, content, dry):
+        captured["content"] = content
+
+    monkeypatch.setattr(script, "_write", fake_write)
+    monkeypatch.setattr(script, "_cmdfile_header", lambda t: "HEADER\n")
+    rows = [{"hostname": "srv1"}]
+    args = SimpleNamespace(
+        user_folder="Users",
+        resource_folder="Resources",
+        schedulejson="{}",
+        rotation_admin_uid=None,
+        dry_run=False,
+        protocol="rdp",
+    )
+    script.write_rotation_commands(rows, args)
+    assert (
+        captured["content"]
+        .strip()
+        .splitlines()[-1]
+        .endswith(f"-sj '{args.schedulejson}'")
+    )
+    # ensure no double spaces
+    assert "  -sj" not in captured["content"]


### PR DESCRIPTION
## Summary
- ignore generated files with `.gitignore`
- document correct script usage and Commander fork
- fix module docstring
- standardize command output formatting and add docstrings
- add unit tests and update README workflow

## Testing
- `flake8 create_pam_script_improved.py`
- `flake8 tests/test_script.py`
- `black --line-length 79 create_pam_script_improved.py tests/test_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685346c4476c8322a7ab8cca464db708